### PR TITLE
fix splash screen red and white HR icons alignment on round watches

### DIFF
--- a/resources-approachs60/layouts/layout.xml
+++ b/resources-approachs60/layouts/layout.xml
@@ -37,6 +37,8 @@
 			<param name="points_5">[[24,172],[24,154],[30,156],[30,174]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="center" y="54" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+		
 		<bitmap id="WorkoutHRIcon" x="126" y="214" filename="../drawables/hr_red_24.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-approachs60/layouts/layout.xml
+++ b/resources-approachs60/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="26" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="31" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="26" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="31" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-fenix5s/layouts/layout.xml
+++ b/resources-fenix5s/layouts/layout.xml
@@ -37,6 +37,8 @@
 			<param name="points_5">[[24,161],[24,143],[30,145],[30,163]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="center" y="46" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+		
 		<bitmap id="WorkoutHRIcon" x="116" y="173" filename="../drawables/hr_red_24.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-fenix5s/layouts/layout.xml
+++ b/resources-fenix5s/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="15" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="23" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="15" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="23" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-fenixchronos/layouts/layout.xml
+++ b/resources-fenixchronos/layouts/layout.xml
@@ -37,6 +37,8 @@
 			<param name="points_5">[[24,161],[24,143],[30,145],[30,163]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="center" y="46" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+		
 		<bitmap id="WorkoutHRIcon" x="116" y="173" filename="../drawables/hr_red_24.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-fenixchronos/layouts/layout.xml
+++ b/resources-fenixchronos/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="15" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="23" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="15" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="23" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-fr920xt/layouts/layout.xml
+++ b/resources-fr920xt/layouts/layout.xml
@@ -42,6 +42,8 @@
 			<param name="points_5">[[24,142],[24,124],[30,126],[30,144]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="35" y="38" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT" />
+		
 		<bitmap id="WorkoutHRIcon" x="135" y="38" filename="../drawables/hr_red_24.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-rectangle-205x148/layouts/layout.xml
+++ b/resources-rectangle-205x148/layouts/layout.xml
@@ -42,6 +42,8 @@
 			<param name="points_5">[[24,142],[24,124],[30,126],[30,144]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="35" y="34" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_LEFT" />
+		
 		<bitmap id="WorkoutHRIcon" x="135" y="38" filename="../drawables/hr_red_24.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-round-218x218/layouts/layout.xml
+++ b/resources-round-218x218/layouts/layout.xml
@@ -37,6 +37,8 @@
 			<param name="points_5">[[24,161],[24,143],[30,145],[30,163]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="center" y="46" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+		
 		<bitmap id="WorkoutHRIcon" x="162" y="171" filename="../drawables/hr_red_24.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-round-218x218/layouts/layout.xml
+++ b/resources-round-218x218/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="15" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="23" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="15" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="23" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-round-240x240/layouts/layout.xml
+++ b/resources-round-240x240/layouts/layout.xml
@@ -37,6 +37,8 @@
 			<param name="points_5">[[24,172],[24,154],[30,158],[30,176]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="center" y="56" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+		
 		<bitmap id="WorkoutHRIcon" x="126" y="214" filename="../drawables/hr_red_24.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-round-240x240/layouts/layout.xml
+++ b/resources-round-240x240/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="75" y="22" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="75" y="31" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="22" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="31" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-semiround-215x180/layouts/layout.xml
+++ b/resources-semiround-215x180/layouts/layout.xml
@@ -37,6 +37,8 @@
 			<param name="points_5">[[24,142],[24,124],[30,126],[30,144]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="center" y="30" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+		
 		<bitmap id="WorkoutHRIcon" x="166" y="152" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-vivoactive3/layouts/layout.xml
+++ b/resources-vivoactive3/layouts/layout.xml
@@ -37,6 +37,8 @@
 			<param name="points_5">[[24,172],[24,154],[30,158],[30,176]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="center" y="55" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+		
 		<bitmap id="WorkoutHRIcon" x="126" y="214" filename="../drawables/hr_red_24.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>

--- a/resources-vivoactive3/layouts/layout.xml
+++ b/resources-vivoactive3/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="26" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="31" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="26" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="31" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources/layouts/layout.xml
+++ b/resources/layouts/layout.xml
@@ -28,6 +28,8 @@
 			<param name="points_5">[[124,174],[144,174],[142,180],[122,180]]</param>
 		</drawable>
 		
+		<label id="StatusTime" x="center" y="70" text="@Strings.StatusBar_time" font="Gfx.FONT_MEDIUM" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+		
 		<bitmap id="WorkoutHRIcon" x="3" y="5" filename="../drawables/hr_red_24.png" />
 		<label id="WorkoutHRbpmText" x="65" y="-2" text="@Strings.Workout_hr_bpm" font="Gfx.FONT_NUMBER_MILD" color="Gfx.COLOR_BLACK" justification="Gfx.TEXT_JUSTIFY_RIGHT" />
 		

--- a/resources/menus/menus.xml
+++ b/resources/menus/menus.xml
@@ -3,6 +3,7 @@
 		<menu-item id="ActivityType">@Strings.ActivityTypeLabel</menu-item>
 		<menu-item id="AllowVibration">@Strings.AllowVibrationLabel</menu-item>
 		<menu-item id="HRStability">@Strings.HRStabilityLabel</menu-item>
+		<menu-item id="TwentyFourHourClock">@Strings.TwentyFourHourClockLabel</menu-item>
 	</menu>
 	<menu id="ActivityTypeMenu">
 		<menu-item id="activity_default">@Strings.activity_default</menu-item>
@@ -24,6 +25,10 @@
 	<menu id="HRStabilityMenu">
 		<menu-item id="HRStabilityOn">@Strings.yes</menu-item>
 		<menu-item id="HRStabilityOff">@Strings.no</menu-item>
+	</menu>
+	<menu id="TwentyFourHourClockMenu">
+		<menu-item id="TwentyFourHourClockOn">@Strings.yes</menu-item>
+		<menu-item id="TwentyFourHourClockOff">@Strings.no</menu-item>
 	</menu>
 	<menu id="EndWorkoutMenu">
 	    <menu-item id="resume">@Strings.resume_workout</menu-item>

--- a/resources/properties/properties.xml
+++ b/resources/properties/properties.xml
@@ -4,4 +4,5 @@
 	<property id="hrStability" type="boolean">true</property>
 	<property id="activityType" type="number">0</property>
 	<property id="activitySubType" type="number">0</property>
+	<property id="twentyFourHourClock" type="boolean">true</property>
 </properties>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -25,4 +25,7 @@
 	<setting propertyKey="@Properties.hrStability" title="@Strings.HRStabilityLabel">
 		<settingConfig type="boolean" />
 	</setting>
+	<setting propertyKey="@Properties.twentyFourHourClock" title="@Strings.TwentyFourHourClockLabel">
+		<settingConfig type="boolean" />
+	</setting>
 </settings>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -16,6 +16,7 @@
 	<string id="ActivitySubTypePrompt">Select the Activity Sub-type</string>
 	<string id="AllowVibrationLabel">Allow Vibration</string>
 	<string id="HRStabilityLabel">HR Stabilizer</string>
+	<string id="TwentyFourHourClockLabel">24-hour Clock</string>
 
 	<string id="hiit_training">HIIT Training</string>
 	

--- a/source/OTFMenuDelegate.mc
+++ b/source/OTFMenuDelegate.mc
@@ -22,6 +22,10 @@ class OTFMenuDelegate extends Ui.MenuInputDelegate {
             Ui.pushView(new Rez.Menus.HRStabilityMenu(), new OTFMenuDelegate(), Ui.SLIDE_UP);
             return true;
         }
+        if (item == :TwentyFourHourClock) {
+            Ui.pushView(new Rez.Menus.TwentyFourHourClockMenu(), new OTFMenuDelegate(), Ui.SLIDE_UP);
+            return true;
+        }
 
         // Activity Type
         if (item == :activity_default) {
@@ -81,6 +85,16 @@ class OTFMenuDelegate extends Ui.MenuInputDelegate {
         }
         if (item == :HRStabilityOff) {
             Prefs.setHRStability(false);
+            return true;
+        }
+        
+        // TwentyFourHourClock
+        if (item == :TwentyFourHourClockOn) {
+            Prefs.setTwentyFourHourClock(true);
+            return true;
+        }
+        if (item == :TwentyFourHourClockOff) {
+            Prefs.setTwentyFourHourClock(false);
             return true;
         }
 

--- a/source/OTFSplashView.mc
+++ b/source/OTFSplashView.mc
@@ -85,13 +85,21 @@ class OTFSplashView extends Ui.View {
     }
 
     hidden function drawSplash() {
-        var time = System.getClockTime();
-        var timeString = Lang.format("$1$:$2$", [time.hour.format("%2.2d"),time.min.format("%2.2d")]);
-        var heartrate = mModel.getHRbpm();
+        var clock = System.getClockTime();
+        var clockString = "";
+    	
+    	if (Prefs.getTwentyFourHourClock()) {
+    		clockString = Lang.format("$1$:$2$", [clock.hour.format("%02d"),clock.min.format("%02d")]);
+    	} else {
+    		var ampm = clock.hour >= 12 ? "PM" : "AM";
+        	clockString = Lang.format("$1$:$2$ $3$", [(clock.hour%12).format("%02d"),clock.min.format("%02d"),ampm]);
+        }
 
-        uiStatusTime.setText( timeString );
+        uiStatusTime.setText( clockString );
 
         // Change the Heart Rate icon and text based on sensor data
+        var heartrate = mModel.getHRbpm();
+        
         // Flashing White is no HR data
         // Steady Red is valid HR data
         if (heartrate == 0 || heartrate == null) {

--- a/source/OTFWorkoutView.mc
+++ b/source/OTFWorkoutView.mc
@@ -14,6 +14,7 @@ class OTFWorkoutView extends Ui.View {
     hidden var mTimer;
 
     //! UI Variables
+    hidden var uiStatusTime;
     hidden var uiTimer;
     hidden var uiHRbpmText;
     hidden var uiCaloriesText;
@@ -36,6 +37,7 @@ class OTFWorkoutView extends Ui.View {
         mModel = Application.getApp().model;
         mController = Application.getApp().controller;
 
+        uiStatusTime = null;
         uiTimer = null;
         uiHRbpmText = null;
         uiCaloriesText = null;
@@ -56,6 +58,7 @@ class OTFWorkoutView extends Ui.View {
         setLayout(Rez.Layouts.PrimaryWorkoutScreen(dc));
 
         // Load UI resources
+        uiStatusTime = View.findDrawableById("StatusTime");
         uiHRbpmText = View.findDrawableById("WorkoutHRbpmText");
         uiTimer = View.findDrawableById("WorkoutTimer");
         uiCaloriesText = View.findDrawableById("WorkoutCaloriesText");
@@ -86,6 +89,18 @@ class OTFWorkoutView extends Ui.View {
 
     //! Update the view
     function onUpdate(dc) {
+    	var clock = System.getClockTime();
+    	var clockString = "";
+    	
+    	if (Prefs.getTwentyFourHourClock()) {
+    		clockString = Lang.format("$1$:$2$", [clock.hour.format("%02d"),clock.min.format("%02d")]);
+    	} else {
+    		var ampm = clock.hour >= 12 ? "PM" : "AM";
+        	clockString = Lang.format("$1$:$2$ $3$", [(clock.hour%12).format("%02d"),clock.min.format("%02d"),ampm]);
+        }
+        
+        uiStatusTime.setText( clockString );
+        
         var curZone = mModel.getHRzone();
         var time = mModel.getTimeElapsed();
         var timeString = Lang.format("$1$:$2$", [time / 60, (time % 60).format("%02d")]);

--- a/source/Prefs.mc
+++ b/source/Prefs.mc
@@ -74,6 +74,17 @@ module Prefs {
         return value;
     }
 
+    //! Set TwentyFourHourClock
+    function setTwentyFourHourClock(value) {
+        App.getApp().setProperty(TWENTYFOURHOUR_CLOCK, value);
+    }
+
+    //! Return boolean of vibration setting
+    function getTwentyFourHourClock() {
+        var value = getBoolean(TWENTYFOURHOUR_CLOCK, true);
+        return value;
+    }
+
     //! Return the number value for a preference, or the given default value if pref
     //! does not exist, is invalid, is less than the min or is greater than the max.
     //! @param name the name of the preference
@@ -138,5 +149,6 @@ module Prefs {
     const ACTIVITY_SUB_TYPE = "activitySubType";
     const ALLOW_VIBRATION = "allowVibration";
     const ALLOW_HRSTABILITY = "allowHRStability";
+    const TWENTYFOURHOUR_CLOCK = "twentyFourHourClock";
 
 }


### PR DESCRIPTION
The red and white HR icons on the splash screen are misaligned on the splash screen. Moved them into the right location and verified on the simulator.