### PR TITLE
fix splash screen red and white HR icons alignment on round watches

### DIFF
--- a/resources-approachs60/layouts/layout.xml
+++ b/resources-approachs60/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="26" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="31" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="26" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="31" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-fenix5s/layouts/layout.xml
+++ b/resources-fenix5s/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="15" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="23" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="15" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="23" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-fenixchronos/layouts/layout.xml
+++ b/resources-fenixchronos/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="15" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="23" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="15" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="23" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-round-218x218/layouts/layout.xml
+++ b/resources-round-218x218/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="15" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="23" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="15" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="23" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-round-240x240/layouts/layout.xml
+++ b/resources-round-240x240/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="75" y="22" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="75" y="31" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="22" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="31" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>

--- a/resources-vivoactive3/layouts/layout.xml
+++ b/resources-vivoactive3/layouts/layout.xml
@@ -2,13 +2,13 @@
 	<layout id="SplashScreen">
 		<drawable id="SplashScreenShapes" />
 		<bitmap id="SplashScreenBg" x="center" y="center" filename="../drawables/hiit_background.png" />
-		<bitmap id="StatusHRIconWhite" x="65" y="26" filename="../drawables/hr_white_16.png" dithering="none">
+		<bitmap id="StatusHRIconWhite" x="65" y="31" filename="../drawables/hr_white_16.png" dithering="none">
 			<palette>
 				<color>FFFFFF</color>
 			</palette>
 		</bitmap>
 		
-		<bitmap id="StatusHRIconRed" x="-50" y="26" filename="../drawables/hr_red_16.png" dithering="none">
+		<bitmap id="StatusHRIconRed" x="-50" y="31" filename="../drawables/hr_red_16.png" dithering="none">
 			<palette>
 				<color>FF1D1D</color>
 			</palette>


### PR DESCRIPTION
The red and white HR icons on the splash screen are misaligned on the splash screen. Moved them into the right location and verified on the simulator. Fixes issue #3 