### PR TITLE
Updated the Max HR to new OTF Formula

### DIFF
--- a/resources/menus/menus.xml
+++ b/resources/menus/menus.xml
@@ -3,6 +3,7 @@
 		<menu-item id="ActivityType">@Strings.ActivityTypeLabel</menu-item>
 		<menu-item id="AllowVibration">@Strings.AllowVibrationLabel</menu-item>
 		<menu-item id="HRStability">@Strings.HRStabilityLabel</menu-item>
+		<menu-item id="MaxHRFormula">@Strings.MaxHRFormulaLabel</menu-item>
 	</menu>
 	<menu id="ActivityTypeMenu">
 		<menu-item id="activity_default">@Strings.activity_default</menu-item>
@@ -16,6 +17,10 @@
 		<menu-item id="activity_sub_cardio">@Strings.activity_sub_cardio</menu-item>
 		<menu-item id="activity_sub_strength">@Strings.activity_sub_strength</menu-item>
 		<menu-item id="activity_sub_flexibility">@Strings.activity_sub_flexibility</menu-item>
+	</menu>
+	<menu id="MaxHRFormulaMenu">
+		<menu-item id="maxhrformula_new">@Strings.maxhrformula_new</menu-item>
+		<menu-item id="maxhrformula_old">@Strings.maxhrformula_old</menu-item>
 	</menu>
 	<menu id="AllowVibrationMenu">
 		<menu-item id="VibrationOn">@Strings.yes</menu-item>

--- a/resources/properties/properties.xml
+++ b/resources/properties/properties.xml
@@ -4,4 +4,5 @@
 	<property id="hrStability" type="boolean">true</property>
 	<property id="activityType" type="number">0</property>
 	<property id="activitySubType" type="number">0</property>
+	<property id="maxHRFormula" type="number">0</property>
 </properties>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -19,6 +19,12 @@
 			<listEntry value="2">@Strings.activity_sub_flexibility</listEntry>
 		</settingConfig>
 	</setting>
+	<setting propertyKey="@Properties.maxHRFormula" title="@Strings.MaxHRFormulaLabel" prompt="@Strings.MaxHRFormulaPrompt">
+		<settingConfig type="list" required="true">
+			<listEntry value="0">@Strings.maxhrformula_new</listEntry>
+			<listEntry value="1">@Strings.maxhrformula_old</listEntry>
+		</settingConfig>
+	</setting>
 	<setting propertyKey="@Properties.allowVibration" title="@Strings.AllowVibrationLabel">
 		<settingConfig type="boolean" />
 	</setting>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -14,6 +14,8 @@
 	<string id="ActivityTypePrompt">Select the Activity Type</string>
 	<string id="ActivitySubTypeLabel">Activity Sub-type</string>
 	<string id="ActivitySubTypePrompt">Select the Activity Sub-type</string>
+	<string id="MaxHRFormulaLabel">Max HR Formula</string>
+	<string id="MaxHRFormulaPrompt">Select the formula for calculating HR Max</string>
 	<string id="AllowVibrationLabel">Allow Vibration</string>
 	<string id="HRStabilityLabel">HR Stabilizer</string>
 
@@ -29,6 +31,9 @@
 	<string id="activity_sub_cardio">Cardio</string>
 	<string id="activity_sub_strength">Strength</string>
 	<string id="activity_sub_flexibility">Flexibility</string>
+	
+	<string id="maxhrformula_new">New Formula</string>
+	<string id="maxhrformula_old">Old Formula</string>
 	
 	<string id="star_label">Star Points</string>
     <string id="star_units">pts</string>

--- a/source/OTFController.mc
+++ b/source/OTFController.mc
@@ -167,6 +167,8 @@ class OTFController
         Log.debug("Preferences Loading");
         // Set Activity Recording Type
         mModel.setActivity(Prefs.getActivityType(), Prefs.getActivitySubType());
+        // Check HR Max Formula
+        Log.debug("MaxHRFormula: " + Prefs.getMaxHRFormula());
         // Set HR Stability
         mModel.setStability(Prefs.getHRStability());
         Log.debug("HR Stability: " + Prefs.getHRStability());

--- a/source/OTFMenuDelegate.mc
+++ b/source/OTFMenuDelegate.mc
@@ -22,6 +22,10 @@ class OTFMenuDelegate extends Ui.MenuInputDelegate {
             Ui.pushView(new Rez.Menus.HRStabilityMenu(), new OTFMenuDelegate(), Ui.SLIDE_UP);
             return true;
         }
+        if (item == :MaxHRFormula) {
+            Ui.pushView(new Rez.Menus.MaxHRFormulaMenu(), new OTFMenuDelegate(), Ui.SLIDE_UP);
+            return true;
+        }
 
         // Activity Type
         if (item == :activity_default) {
@@ -61,6 +65,16 @@ class OTFMenuDelegate extends Ui.MenuInputDelegate {
         }
         if (item == :activity_sub_flexibility) {
             Prefs.setActivitySubType(Prefs.SUB_FLEXIBILITY);
+            return true;
+        }
+
+        // Max HR Formula
+        if (item == :maxhrformula_new) {
+            Prefs.setMaxHRFormula(Prefs.FORMULA_NEW);
+            return true;
+        }
+        if (item == :maxhrformula_old) {
+            Prefs.setMaxHRFormula(Prefs.FORMULA_OLD);
             return true;
         }
 

--- a/source/Prefs.mc
+++ b/source/Prefs.mc
@@ -30,6 +30,12 @@ module Prefs {
         SUB_FLEXIBILITY = 2
     }
 
+    //! Max HR Formulas
+    enum {
+        FORMULA_NEW = 0,
+        FORMULA_OLD = 1
+    }
+
     //! Store activity type
     function setActivityType(type) {
         App.getApp().setProperty(ACTIVITY_TYPE, type);
@@ -50,6 +56,17 @@ module Prefs {
     function getActivitySubType() {
         var subType = getNumber(ACTIVITY_SUB_TYPE, 0, 0, 100);
         return subType;
+    }
+
+    //! Store max HR formula
+    function setMaxHRFormula(type) {
+        App.getApp().setProperty(MAXHRFORMULA, type);
+    }
+
+    //! Get max HR formula
+    function getMaxHRFormula() {
+        var formula = getNumber(MAXHRFORMULA, 0, 0, 100);
+        return formula;
     }
 
     //! Set vibration policy
@@ -136,6 +153,7 @@ module Prefs {
     // Settings name, see resources/settings.xml
     const ACTIVITY_TYPE = "activityType";
     const ACTIVITY_SUB_TYPE = "activitySubType";
+    const MAXHRFORMULA = "maxHRFormula";
     const ALLOW_VIBRATION = "allowVibration";
     const ALLOW_HRSTABILITY = "allowHRStability";
 


### PR DESCRIPTION
Updated the Max HR Formula to the new formula used by OTF. 

OFT Changed their formula based on this research data: https://www.ncbi.nlm.nih.gov/pubmed/11153730

I have added a new setting that allows someone to go back to the old formula if needed since some of the people in the reviews said they liked the old formula better. It defaults to the new formula. 

I've tested it on the simulator and on a real watch in multiple OTF classes and it matches their data exactly.